### PR TITLE
Change the way to get all the components

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Site Editor</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,5 +3,21 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react()]
+    plugins: [react()],
+    resolve: {
+        alias: [
+            {
+                find: '@assets',
+                replacement: '@react-site-editor/frontend/src/assets'
+            },
+            {
+                find: '@components',
+                replacement: '@react-site-editor/frontend/src/components'
+            },
+            {
+                find: '@pages',
+                replacement: '@react-site-editor/frontend/src/pages'
+            },
+        ],
+  },
 });

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
             {
                 find: '@pages',
                 replacement: '@react-site-editor/frontend/src/pages'
-            },
-        ],
-  },
+            }
+        ]
+    }
 });

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,1 +1,6 @@
-console.log('Not implemented');
+export interface Component {
+    caller: React.FunctionComponent,
+    defaultProps: {
+        [prop: string]: any;
+    }
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,6 +1,6 @@
 export interface Component {
-    caller: React.FunctionComponent,
+    caller: React.FunctionComponent;
     defaultProps: {
         [prop: string]: any;
-    }
+    };
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,17 +1,33 @@
 import React from 'react';
+import type { Component } from '@react-site-editor/types';
 
-interface Props {
-    text: string;
-    onClick: () => void;
+interface ButtonProps {
+    text?: string;
+    onClick?: () => void;
     style?: React.CSSProperties;
 }
 
-const Button: React.FC<Props> = ({ text, onClick, style }) => {
+const defaultButtonProps: ButtonProps = {
+    text: 'Button',
+    onClick: () => {},
+    style: {
+        backgroundColor: 'blue',
+        color: 'white',
+        padding: '10px 20px'
+    }
+}
+
+const Button: React.FC<ButtonProps> = (props) => {
     return (
-        <button style={style} onClick={onClick}>
-            {text}
+        <button style={props?.style} onClick={props?.onClick}>
+            {props?.text}
         </button>
     );
 };
 
-export default Button;
+const ButtonComponent: Component = {
+    caller: Button,
+    defaultProps: defaultButtonProps
+};
+
+export default ButtonComponent;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -9,13 +9,13 @@ interface ButtonProps {
 
 const defaultButtonProps: ButtonProps = {
     text: 'Button',
-    onClick: () => {},
+    onClick: () => console.log('Button clicked'),
     style: {
         backgroundColor: 'blue',
         color: 'white',
         padding: '10px 20px'
     }
-}
+};
 
 const Button: React.FC<ButtonProps> = (props) => {
     return (

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,4 +1,25 @@
 import './index.css';
 import Button from './components/Button';
+import type { Component } from '@react-site-editor/types';
 
+type ComponentsMap = Record<string, Component>;
+
+async function getAllComponents() {
+    const files = import.meta.glob('./components/*.tsx');
+    const components: ComponentsMap = {};
+
+    for (const filepath in files) {
+        const filename = filepath.match(/.*\/(.+)\.tsx$/)?.[1];
+
+        if (filename) {
+            const component = await import(`./components/${filename}.tsx`);
+            components[filename] = component.default;
+        }
+    }
+    return components as ComponentsMap;
+}
+
+export const components = await getAllComponents();
+
+// To be removed
 export { Button };


### PR DESCRIPTION
The `findAllComponents` function was not working, due to some problems with the `fs` package.

So I come up with a new solution, directly implemented in `packages/ui/src/main.tsx`.

With that method, components file in the package should follow this pattern:

```ts
import React from 'react';
import type { Component } from '@react-site-editor/types';

interface MyComponentProps {
    prop: any;
    style?: React.CSSProperties;
}

const defaultMyComponentProps: MyComponentProps = {
    prop: 'defaultValue',
    style: {
        default: style;
    }
};

const MyComponent: React.FunctionComponent<MyComponentProps> = (props) => {
    return (
        ...
    );
};

const MyComponentComponent: Component = {
    caller: MyComponent,
    defaultProps: defaultMyComponentProps
};

export default MyComponentComponent;
```

I updated the `Buttton.tsx` in consequence.