### PR TITLE
Add a global layout to start

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,6 +17,7 @@ plugins:
 rules:
     no-shadow: off
     no-use-before-define: off
+    'react/prop-types': 'off'
     'react/react-in-jsx-scope': 'off'
     'react/jsx-pascal-case': 'error'
     'react/no-deprecated': 'error'

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Site Editor</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,11 +8,11 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@react-site-editor/ui": "1.0.0",
         "@react-site-editor/functions": "1.0.0",
+        "@react-site-editor/ui": "1.0.0",
+        "postcss": "^8.4.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "postcss": "^8.4.21",
         "tailwindcss": "^3.2.4"
     },
     "devDependencies": {

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,17 +1,9 @@
-import { Button } from '@react-site-editor/ui';
+import EditorPage from './pages/EditorPage/EditorPage';
 
 function App() {
     return (
         <div>
-            <Button
-                text="Click me"
-                onClick={() => alert('Button was clicked!')}
-                style={{
-                    backgroundColor: 'blue',
-                    color: 'white',
-                    padding: '10px 20px'
-                }}
-            />
+            <EditorPage />
         </div>
     );
 }

--- a/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.module.css
+++ b/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.module.css
@@ -1,0 +1,8 @@
+.container {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    height: fit-content;
+    padding-block: .5em;
+    border: 1px solid lightblue;
+}

--- a/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -2,15 +2,15 @@ import ComponentWrapperStyle from './ComponentWrapper.module.css';
 
 interface ComponentWrapperProps {
     // any prop
-    children?: React.ReactNode | React.ReactNode[]
+    children?: React.ReactNode | React.ReactNode[];
 }
 
-const ComponentWrapper: React.FunctionComponent<ComponentWrapperProps> = (props) => {
+const ComponentWrapper: React.FunctionComponent<ComponentWrapperProps> = (
+    props
+) => {
     return (
-        <div className={ComponentWrapperStyle.container}>
-            {props.children}
-        </div>
-    )
+        <div className={ComponentWrapperStyle.container}>{props.children}</div>
+    );
 };
 
 export default ComponentWrapper;

--- a/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/apps/frontend/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -1,0 +1,16 @@
+import ComponentWrapperStyle from './ComponentWrapper.module.css';
+
+interface ComponentWrapperProps {
+    // any prop
+    children?: React.ReactNode | React.ReactNode[]
+}
+
+const ComponentWrapper: React.FunctionComponent<ComponentWrapperProps> = (props) => {
+    return (
+        <div className={ComponentWrapperStyle.container}>
+            {props.children}
+        </div>
+    )
+};
+
+export default ComponentWrapper;

--- a/apps/frontend/src/components/SideBar/SideBar.module.css
+++ b/apps/frontend/src/components/SideBar/SideBar.module.css
@@ -1,0 +1,14 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    box-shadow: 0 1px 2px 1px #00000022;
+}
+
+.scale1 {
+    width: 25vw;
+}
+
+.scale2 {
+    width: 20vw;
+}

--- a/apps/frontend/src/components/SideBar/SideBar.tsx
+++ b/apps/frontend/src/components/SideBar/SideBar.tsx
@@ -4,15 +4,18 @@ type SideBarScale = '1' | '2';
 
 interface SideBarProps {
     scale: SideBarScale;
-    children?: React.ReactNode | React.ReactNode[]
+    children?: React.ReactNode | React.ReactNode[];
 }
 
 const SideBar: React.FunctionComponent<SideBarProps> = (props) => {
     return (
-        <div className={`${SideBarStyle.container} ${SideBarStyle[`scale${props.scale}`]}`}>
+        <div
+            className={`${SideBarStyle.container} ${
+                SideBarStyle[`scale${props.scale}`]
+            }`}>
             {props.children}
         </div>
-    )
+    );
 };
 
 export default SideBar;

--- a/apps/frontend/src/components/SideBar/SideBar.tsx
+++ b/apps/frontend/src/components/SideBar/SideBar.tsx
@@ -1,0 +1,18 @@
+import SideBarStyle from './SideBar.module.css';
+
+type SideBarScale = '1' | '2';
+
+interface SideBarProps {
+    scale: SideBarScale;
+    children?: React.ReactNode | React.ReactNode[]
+}
+
+const SideBar: React.FunctionComponent<SideBarProps> = (props) => {
+    return (
+        <div className={`${SideBarStyle.container} ${SideBarStyle[`scale${props.scale}`]}`}>
+            {props.children}
+        </div>
+    )
+};
+
+export default SideBar;

--- a/apps/frontend/src/components/SideBarHeader/SideBarHeader.module.css
+++ b/apps/frontend/src/components/SideBarHeader/SideBarHeader.module.css
@@ -1,0 +1,5 @@
+.container {
+    width: 100%;
+    height: 75px;
+    box-shadow: 0 1px 3px 0 #00000022;
+}

--- a/apps/frontend/src/components/SideBarHeader/SideBarHeader.tsx
+++ b/apps/frontend/src/components/SideBarHeader/SideBarHeader.tsx
@@ -1,11 +1,9 @@
 import SideBarHeaderStyle from './SideBarHeader.module.css';
 
-const SideBarHeader: React.FunctionComponent<React.PropsWithChildren> = (props) => {
-    return (
-        <div className={SideBarHeaderStyle.container}>
-            {props.children}
-        </div>
-    )
+const SideBarHeader: React.FunctionComponent<React.PropsWithChildren> = (
+    props
+) => {
+    return <div className={SideBarHeaderStyle.container}>{props.children}</div>;
 };
 
 export default SideBarHeader;

--- a/apps/frontend/src/components/SideBarHeader/SideBarHeader.tsx
+++ b/apps/frontend/src/components/SideBarHeader/SideBarHeader.tsx
@@ -1,0 +1,11 @@
+import SideBarHeaderStyle from './SideBarHeader.module.css';
+
+const SideBarHeader: React.FunctionComponent<React.PropsWithChildren> = (props) => {
+    return (
+        <div className={SideBarHeaderStyle.container}>
+            {props.children}
+        </div>
+    )
+};
+
+export default SideBarHeader;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,0 +1,4 @@
+* {
+    margin: 0;
+    padding: 0;
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
         <App />

--- a/apps/frontend/src/pages/EditorPage/EditorPage.module.css
+++ b/apps/frontend/src/pages/EditorPage/EditorPage.module.css
@@ -1,0 +1,25 @@
+.container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.preview {
+    flex: 1;
+    height: 100vh;
+}
+
+.componentsList {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    list-style: none;
+}
+
+.componentsListItem {
+    cursor: pointer;
+    width: 95%;
+    margin-inline: auto;
+    margin-block: 1em;
+}

--- a/apps/frontend/src/pages/EditorPage/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage/EditorPage.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import EditorStyle from './EditorPage.module.css';
+import SideBar from '../../components/SideBar/SideBar';
+import SideBarHeader from '../../components/SideBarHeader/SideBarHeader';
+import ComponentWrapper from '../../components/ComponentWrapper/ComponentWrapper';
+import { components } from '@react-site-editor/ui';
+
+const EditorPage: React.FunctionComponent = () => {
+    const [selectedComponent, setSelectedComponent] = useState<string | null>(null);
+
+    return (
+        <div className={EditorStyle.container}>
+            <SideBar scale="1">
+                <SideBarHeader>
+
+                </SideBarHeader>
+                <ul className={EditorStyle.componentsList}>
+                    {Object.entries(components).map(
+                        ([componentName, component]) => {
+                        return (
+                            <li className={EditorStyle.componentsListItem}
+                                key={componentName}
+                                onClick={() => setSelectedComponent(componentName)}>
+                                <ComponentWrapper>
+                                    {component.caller(component.defaultProps)}
+                                </ComponentWrapper>
+                            </li>
+                        )
+                    })}
+                </ul>
+            </SideBar>
+            <div className={EditorStyle.preview}>
+
+            </div>
+            <SideBar scale="2">
+                <SideBarHeader>
+                    <h2>{selectedComponent}</h2>
+                </SideBarHeader>
+                {selectedComponent
+                    ? Object.keys(components[selectedComponent]?.defaultProps)
+                    : ''}
+            </SideBar>
+        </div>
+    )
+};
+
+export default EditorPage;

--- a/apps/frontend/src/pages/EditorPage/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage/EditorPage.tsx
@@ -6,32 +6,36 @@ import ComponentWrapper from '../../components/ComponentWrapper/ComponentWrapper
 import { components } from '@react-site-editor/ui';
 
 const EditorPage: React.FunctionComponent = () => {
-    const [selectedComponent, setSelectedComponent] = useState<string | null>(null);
+    const [selectedComponent, setSelectedComponent] = useState<string | null>(
+        null
+    );
 
     return (
         <div className={EditorStyle.container}>
             <SideBar scale="1">
-                <SideBarHeader>
-
-                </SideBarHeader>
+                <SideBarHeader></SideBarHeader>
                 <ul className={EditorStyle.componentsList}>
                     {Object.entries(components).map(
                         ([componentName, component]) => {
-                        return (
-                            <li className={EditorStyle.componentsListItem}
-                                key={componentName}
-                                onClick={() => setSelectedComponent(componentName)}>
-                                <ComponentWrapper>
-                                    {component.caller(component.defaultProps)}
-                                </ComponentWrapper>
-                            </li>
-                        )
-                    })}
+                            return (
+                                <li
+                                    className={EditorStyle.componentsListItem}
+                                    key={componentName}
+                                    onClick={() =>
+                                        setSelectedComponent(componentName)
+                                    }>
+                                    <ComponentWrapper>
+                                        {component.caller(
+                                            component.defaultProps
+                                        )}
+                                    </ComponentWrapper>
+                                </li>
+                            );
+                        }
+                    )}
                 </ul>
             </SideBar>
-            <div className={EditorStyle.preview}>
-
-            </div>
+            <div className={EditorStyle.preview}></div>
             <SideBar scale="2">
                 <SideBarHeader>
                     <h2>{selectedComponent}</h2>
@@ -41,7 +45,7 @@ const EditorPage: React.FunctionComponent = () => {
                     : ''}
             </SideBar>
         </div>
-    )
+    );
 };
 
 export default EditorPage;

--- a/apps/frontend/src/pages/HomePage/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage/HomePage.tsx
@@ -3,19 +3,17 @@ import { Button } from '@react-site-editor/ui';
 const HomePage: React.FunctionComponent = () => {
     return (
         <div className="Home">
-            {
-                Button.caller({
-                    text:"Click me",
-                    onClick: () => alert('Button was clicked!'),
-                    style: {
-                        backgroundColor: 'blue',
-                        color: 'white',
-                        padding: '10px 20px'
-                    }
-                })
-            }
+            {Button.caller({
+                text: 'Click me',
+                onClick: () => alert('Button was clicked!'),
+                style: {
+                    backgroundColor: 'blue',
+                    color: 'white',
+                    padding: '10px 20px'
+                }
+            })}
         </div>
-    )
+    );
 };
 
 export default HomePage;

--- a/apps/frontend/src/pages/HomePage/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage/HomePage.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@react-site-editor/ui';
+
+const HomePage: React.FunctionComponent = () => {
+    return (
+        <div className="Home">
+            {
+                Button.caller({
+                    text:"Click me",
+                    onClick: () => alert('Button was clicked!'),
+                    style: {
+                        backgroundColor: 'blue',
+                        color: 'white',
+                        padding: '10px 20px'
+                    }
+                })
+            }
+        </div>
+    )
+};
+
+export default HomePage;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,5 +3,21 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react()]
+    plugins: [react()],
+    resolve: {
+        alias: [
+            {
+                find: '@assets',
+                replacement: '@react-site-editor/frontend/src/assets'
+            },
+            {
+                find: '@components',
+                replacement: '@react-site-editor/frontend/src/components'
+            },
+            {
+                find: '@pages',
+                replacement: '@react-site-editor/frontend/src/pages'
+            },
+        ],
+  },
 });

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
             {
                 find: '@pages',
                 replacement: '@react-site-editor/frontend/src/pages'
-            },
-        ],
-  },
+            }
+        ]
+    }
 });

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,1 +1,6 @@
-console.log('Not implemented');
+export interface Component {
+    caller: React.FunctionComponent,
+    defaultProps: {
+        [prop: string]: any;
+    }
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,6 +1,6 @@
 export interface Component {
-    caller: React.FunctionComponent,
+    caller: React.FunctionComponent;
     defaultProps: {
         [prop: string]: any;
-    }
+    };
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,17 +1,33 @@
 import React from 'react';
+import type { Component } from '@react-site-editor/types';
 
-interface Props {
-    text: string;
-    onClick: () => void;
+interface ButtonProps {
+    text?: string;
+    onClick?: () => void;
     style?: React.CSSProperties;
 }
 
-const Button: React.FC<Props> = ({ text, onClick, style }) => {
+const defaultButtonProps: ButtonProps = {
+    text: 'Button',
+    onClick: () => {},
+    style: {
+        backgroundColor: 'blue',
+        color: 'white',
+        padding: '10px 20px'
+    }
+}
+
+const Button: React.FC<ButtonProps> = (props) => {
     return (
-        <button style={style} onClick={onClick}>
-            {text}
+        <button style={props?.style} onClick={props?.onClick}>
+            {props?.text}
         </button>
     );
 };
 
-export default Button;
+const ButtonComponent: Component = {
+    caller: Button,
+    defaultProps: defaultButtonProps
+};
+
+export default ButtonComponent;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -9,13 +9,13 @@ interface ButtonProps {
 
 const defaultButtonProps: ButtonProps = {
     text: 'Button',
-    onClick: () => {},
+    onClick: () => console.log('Button clicked'),
     style: {
         backgroundColor: 'blue',
         color: 'white',
         padding: '10px 20px'
     }
-}
+};
 
 const Button: React.FC<ButtonProps> = (props) => {
     return (

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,4 +1,25 @@
 import './index.css';
 import Button from './components/Button';
+import type { Component } from '@react-site-editor/types';
 
+type ComponentsMap = Record<string, Component>;
+
+async function getAllComponents() {
+    const files = import.meta.glob('./components/*.tsx');
+    const components: ComponentsMap = {};
+
+    for (const filepath in files) {
+        const filename = filepath.match(/.*\/(.+)\.tsx$/)?.[1];
+
+        if (filename) {
+            const component = await import(`./components/${filename}.tsx`);
+            components[filename] = component.default;
+        }
+    }
+    return components as ComponentsMap;
+}
+
+export const components = await getAllComponents();
+
+// To be removed
 export { Button };


### PR DESCRIPTION
This depends on the PR #16 

The page will look like this (the `EditorPage` view):
<br>
<img src="https://user-images.githubusercontent.com/64146788/217510334-4941bbe3-a246-4573-9960-da25739b13ca.png" width="90%"/>

<br>
When clicking on the component to the left, we have something like this:
<br><br>
<img src="https://user-images.githubusercontent.com/64146788/217510452-7efbb6f3-1504-4f62-8a45-787d6d10fc06.png" width="90%"/>

